### PR TITLE
Glossary guard

### DIFF
--- a/glossary_preproc.rb
+++ b/glossary_preproc.rb
@@ -40,7 +40,7 @@ all_glossary_items = Dir.glob('_skt_glossary/*.md').map do |item_fname|
   GlossaryItem.new(item_fname)
 end
 
-puts "[DEBUG] DONE reading glossary items" if DEBUG
+puts '[DEBUG] DONE reading glossary items' if DEBUG
 
 markdown_fname = ARGV.first
 markdown_file = FrontMatterParser::Parser.parse_file(markdown_fname)
@@ -50,11 +50,12 @@ all_glossary_items.each do |glossary_term|
   count = 0
 
   # We must only replace full words that are not enclosed in quotes
-  markdown_file.content.gsub!(/\b(?!<")#{glossary_term.title}(?!")\b/) { |m| count +=1; m.replace("{% include glossary_link.html title=\"#{glossary_term.title}\" %}")}
+  markdown_file.content.gsub!(/(?!<{%.*?)\b#{glossary_term.title}\b(?!.*?%})/) { |m| count +=1; m.replace("{% include glossary_link.html title=\"#{glossary_term.title}\" %}")}
+  markdown_file.content.gsub!(/(?!<{%.*?)\b#{glossary_term.slug}\b(?!.*?%})/) { |m| count +=1; m.replace("{% include glossary_link.html title=\"#{glossary_term.slug}\" name=\"#{glossary_term.title}\" %}")}
 
-  markdown_file.content.gsub!(/\b(?!<")#{glossary_term.slug}(?!")\b/) { |m| count +=1; m.replace("{% include glossary_link.html title=\"#{glossary_term.slug}\" name=\"#{glossary_term.title}\" %}")}
-
-  puts "[DEBUG] ... #{count} times!"
+  if DEBUG
+    puts "[DEBUG] ... #{count} times!" unless count.zero?
+  end
 end
 
 File.open(markdown_fname, 'w') do |output_file|

--- a/skt/_posts/2018-05-12-s01e02.md
+++ b/skt/_posts/2018-05-12-s01e02.md
@@ -51,8 +51,8 @@ einem gewissen {% include glossary_link.html title="Hark" %} -- gefangen
 gehalten werden.
 
 Wir schicken die Bewohner zurück nach {% include glossary_link.html
-title="Nightstone" %} und suchen {% include glossary_link.html title="Hark"
-%}. Der ist auch nicht schwer zu finden, und wir können ihn ohne einen Kampf
+title="Nightstone" %} und suchen {% include glossary_link.html title="Hark" %}
+Der ist auch nicht schwer zu finden, und wir können ihn ohne einen Kampf
 gefangen nehmen. Lilleni und Ean finden und plündern seine persönlichen
 Gemächer. Ean scheint insbesondere von einem religiösen Talisman fasziniert zu
 sein, den er dort findet…

--- a/skt/_posts/2019-01-26-s01e18.md
+++ b/skt/_posts/2019-01-26-s01e18.md
@@ -64,10 +64,11 @@ Falle herausstellt. Und das Gold ist auch noch gefälscht.
 In einem der Türme befindet sich ein Teleskop. Der Riese, der es wohl bedienen sollte, ist tot,
 möglicherweise ebenfalls vergiftet. Wir versuchen das Teleskop zu verstehen, scheitern aber.
 
-Im letzten Turm befindet sich {% include glossary_link.html name="Olthana"
-title="Olthanas" %} Schlafzimmer. Wir finden ihr Tagebuch: {% include glossary_link.html title="Olthana" %} ist wohl besorgt, weil ihre
-Schwester, die Gräfin *Sansuri*, eine Anhängerin von *Memnor* ist, der die Schwertküste attackieren
-möchte. Vom Verrat ihrer Hofmeisterin hat sie wohl keinen Schimmer.
+Im letzten Turm befindet sich {% include glossary_link.html name="Olthana" title="Olthanas" %}
+Schlafzimmer. Wir finden ihr Tagebuch: {% include glossary_link.html title="Olthana" %} ist wohl
+besorgt, weil ihre Schwester, die Gräfin *Sansuri*, eine Anhängerin von
+*Memnor* ist, der die Schwertküste attackieren möchte. Vom Verrat ihrer
+Hofmeisterin hat sie wohl keinen Schimmer.
 
 ---
 


### PR DESCRIPTION
Damit sollte jetzt auch ein mehrere Worte umfassender Liquid Tag nicht mehr matchen. Dafür ist aber notwendig, dass Liquid Tags nicht über mehrere Zeilen gehen.